### PR TITLE
Section 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "bcryptjs": "^2.4.3",
         "date-fns": "^3.6.0",
         "framer-motion": "^11.2.6",
-        "next": "14.2.3",
+        "next": "^14.2.4",
         "next-auth": "^5.0.0-beta.19",
         "react": "^18",
         "react-dom": "^18",
@@ -382,9 +382,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA=="
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.4.tgz",
+      "integrity": "sha512-3EtkY5VDkuV2+lNmKlbkibIJxcO4oIHEhBWne6PaAp+76J9KoSsGvNikp6ivzAT8dhhBMYrm6op2pS1ApG0Hzg=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.3",
@@ -396,9 +396,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
-      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.4.tgz",
+      "integrity": "sha512-AH3mO4JlFUqsYcwFUHb1wAKlebHU/Hv2u2kb1pAuRanDZ7pD/A/KPD98RHZmwsJpdHQwfEc/06mgpSzwrJYnNg==",
       "cpu": [
         "arm64"
       ],
@@ -411,9 +411,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
-      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.4.tgz",
+      "integrity": "sha512-QVadW73sWIO6E2VroyUjuAxhWLZWEpiFqHdZdoQ/AMpN9YWGuHV8t2rChr0ahy+irKX5mlDU7OY68k3n4tAZTg==",
       "cpu": [
         "x64"
       ],
@@ -426,9 +426,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
-      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.4.tgz",
+      "integrity": "sha512-KT6GUrb3oyCfcfJ+WliXuJnD6pCpZiosx2X3k66HLR+DMoilRb76LpWPGb4tZprawTtcnyrv75ElD6VncVamUQ==",
       "cpu": [
         "arm64"
       ],
@@ -441,9 +441,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
-      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.4.tgz",
+      "integrity": "sha512-Alv8/XGSs/ytwQcbCHwze1HmiIkIVhDHYLjczSVrf0Wi2MvKn/blt7+S6FJitj3yTlMwMxII1gIJ9WepI4aZ/A==",
       "cpu": [
         "arm64"
       ],
@@ -456,9 +456,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
-      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.4.tgz",
+      "integrity": "sha512-ze0ShQDBPCqxLImzw4sCdfnB3lRmN3qGMB2GWDRlq5Wqy4G36pxtNOo2usu/Nm9+V2Rh/QQnrRc2l94kYFXO6Q==",
       "cpu": [
         "x64"
       ],
@@ -471,9 +471,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
-      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.4.tgz",
+      "integrity": "sha512-8dwC0UJoc6fC7PX70csdaznVMNr16hQrTDAMPvLPloazlcaWfdPogq+UpZX6Drqb1OBlwowz8iG7WR0Tzk/diQ==",
       "cpu": [
         "x64"
       ],
@@ -486,9 +486,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
-      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.4.tgz",
+      "integrity": "sha512-jxyg67NbEWkDyvM+O8UDbPAyYRZqGLQDTPwvrBBeOSyVWW/jFQkQKQ70JDqDSYg1ZDdl+E3nkbFbq8xM8E9x8A==",
       "cpu": [
         "arm64"
       ],
@@ -501,9 +501,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
-      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.4.tgz",
+      "integrity": "sha512-twrmN753hjXRdcrZmZttb/m5xaCBFa48Dt3FbeEItpJArxriYDunWxJn+QFXdJ3hPkm4u7CKxncVvnmgQMY1ag==",
       "cpu": [
         "ia32"
       ],
@@ -516,9 +516,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
-      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.4.tgz",
+      "integrity": "sha512-tkLrjBzqFTP8DVrAAQmZelEahfR9OxWpFR++vAI9FBhCiIxtwHwBHC23SBHCTURBtwB4kc/x44imVOnkKGNVGg==",
       "cpu": [
         "x64"
       ],
@@ -6093,11 +6093,11 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
-      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
+      "version": "14.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.4.tgz",
+      "integrity": "sha512-R8/V7vugY+822rsQGQCjoLhMuC9oFj9SOi4Cl4b2wjDrseD0LRZ10W7R6Czo4w9ZznVSshKjuIomsRjvm9EKJQ==",
       "dependencies": {
-        "@next/env": "14.2.3",
+        "@next/env": "14.2.4",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -6112,15 +6112,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.3",
-        "@next/swc-darwin-x64": "14.2.3",
-        "@next/swc-linux-arm64-gnu": "14.2.3",
-        "@next/swc-linux-arm64-musl": "14.2.3",
-        "@next/swc-linux-x64-gnu": "14.2.3",
-        "@next/swc-linux-x64-musl": "14.2.3",
-        "@next/swc-win32-arm64-msvc": "14.2.3",
-        "@next/swc-win32-ia32-msvc": "14.2.3",
-        "@next/swc-win32-x64-msvc": "14.2.3"
+        "@next/swc-darwin-arm64": "14.2.4",
+        "@next/swc-darwin-x64": "14.2.4",
+        "@next/swc-linux-arm64-gnu": "14.2.4",
+        "@next/swc-linux-arm64-musl": "14.2.4",
+        "@next/swc-linux-x64-gnu": "14.2.4",
+        "@next/swc-linux-x64-musl": "14.2.4",
+        "@next/swc-win32-arm64-msvc": "14.2.4",
+        "@next/swc-win32-ia32-msvc": "14.2.4",
+        "@next/swc-win32-x64-msvc": "14.2.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bcryptjs": "^2.4.3",
     "date-fns": "^3.6.0",
     "framer-motion": "^11.2.6",
-    "next": "14.2.3",
+    "next": "^14.2.4",
     "next-auth": "^5.0.0-beta.19",
     "react": "^18",
     "react-dom": "^18",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,8 @@ model Member {
   image       String?
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   photos      Photo[]
+  sourceLike  Like[] @relation("source")
+  targetLike  Like[] @relation("target")
 }
 
 model Photo {
@@ -67,4 +69,16 @@ model Account {
   user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([provider, providerAccountId])
+}
+
+
+model Like {
+  sourceUserId String 
+  sourceMember Member @relation("source", fields:[sourceUserId], references: [userId], onDelete: Cascade)
+
+  targetUserId String
+  targetMember Member @relation("target", fields:[targetUserId], references: [userId], onDelete: Cascade)
+
+  @@id([sourceUserId, targetUserId])
+
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -38,22 +38,21 @@ async function main() {
   await seedMembers()
 }
 
-// main()
-updateUserImage()
-  .catch(e => {
-    console.error(e)
-    process.exit(1)
-  })
-  .finally(async () => await prisma.$disconnect())
-
-
-  async function updateUserImage() {
-    for (const member of membersData) {
-      await prisma.user.updateMany({
-        where: { name: member.name },
-        data: {
-          image: member.image,
-        },
-      })
-    }
+async function updateUserImage() {
+  for (const member of membersData) {
+    await prisma.user.updateMany({
+      where: { name: member.name },
+      data: {
+        image: member.image,
+      },
+    })
   }
+}
+
+  main()
+    // updateUserImage()
+    .catch(e => {
+      console.error(e)
+      process.exit(1)
+    })
+    .finally(async () => await prisma.$disconnect())

--- a/src/app/actions/authActions.ts
+++ b/src/app/actions/authActions.ts
@@ -9,7 +9,7 @@ import {
 import type { ActionResult } from "../../types"
 import type { User } from "@prisma/client"
 import bcrypt from "bcryptjs"
-import { signIn } from "@/auth"
+import { auth, signIn } from "@/auth"
 import { AuthError } from "next-auth"
 
 export async function registerUser(
@@ -73,4 +73,12 @@ export async function signInUser(
     }
     return { status: "error", error: "Sign in internal error" }
   }
+}
+
+
+export const getCurrentUserId = async () => {
+  const session = await auth()
+  const userId = session?.user?.id
+  if (!userId) throw new Error("Not authorized")
+  return userId
 }

--- a/src/app/actions/likeActions.ts
+++ b/src/app/actions/likeActions.ts
@@ -1,16 +1,19 @@
-import { auth } from "@/auth"
+"use server"
 import { prisma } from "@/lib/prisma"
 import { getCurrentUserId } from "./authActions"
 
 /**
  * Toggles the like status of a target for the logged in user
  */
-export const toggleLike = async (targetUserId: string, isLiked: boolean) => {
+export const toggleLikeMember = async (
+  targetUserId: string,
+  isLiked: boolean
+) => {
   try {
     const userId = await getCurrentUserId()
 
     if (isLiked) {
-      prisma.like.delete({
+      await prisma.like.delete({
         where: {
           sourceUserId_targetUserId: {
             sourceUserId: userId,
@@ -19,7 +22,7 @@ export const toggleLike = async (targetUserId: string, isLiked: boolean) => {
         },
       })
     } else {
-      prisma.like.create({
+      await prisma.like.create({
         data: { sourceUserId: userId, targetUserId },
       })
     }
@@ -32,7 +35,7 @@ export const toggleLike = async (targetUserId: string, isLiked: boolean) => {
 /**
  * @returns all target likes for the current user, ie, who has the current user liked
  */
-export const fetchCurrentUserLikeIds = async () => {
+export const fetchTargetLikeIds = async () => {
   try {
     const userId = await getCurrentUserId()
     const likes = await prisma.like.findMany({
@@ -44,7 +47,7 @@ export const fetchCurrentUserLikeIds = async () => {
       },
     })
     console.log(
-      "#####🚀🚀🚀 ~ file: likeActions.ts:46 ~ fetchCurrentUserLikeIds ~ likes➡️➡️➡️",
+      "#####🚀🚀🚀 ~ file: likeActions.ts:46 ~ fetchCurrentUserLikeIds ~ likes➡️ ➡️ ➡️",
       likes
     )
     return likes.map(like => like.targetUserId)

--- a/src/app/actions/likeActions.ts
+++ b/src/app/actions/likeActions.ts
@@ -39,8 +39,8 @@ export const toggleLikeMember = async (
  * @returns array of member Ids or members
  */
 export const fetchLikesForCurrentUser = async (
-  type: "source" | "target" | "mutual",
-  select: "id" | "member"
+  type: "source" | "target" | "mutual" = "source",
+  select: "id" | "member" = "id"
 ): Promise<string[] | Member[]> => {
   try {
     const userId = await getCurrentUserId()

--- a/src/app/actions/likeActions.ts
+++ b/src/app/actions/likeActions.ts
@@ -33,13 +33,15 @@ export const toggleLikeMember = async (
   }
 }
 
+export type LikeTypes = "source" | "target" | "mutual"
+
 /**
  * @param type whether the current user is the source, target or mutual target of likes
  * @param select whether to return the member Ids or members that meet the like type
  * @returns array of member Ids or members
  */
 export const fetchLikesForCurrentUser = async (
-  type: "source" | "target" | "mutual" = "source",
+  type: LikeTypes = "source",
   select: "id" | "member" = "id"
 ): Promise<string[] | Member[]> => {
   try {

--- a/src/app/actions/likeActions.ts
+++ b/src/app/actions/likeActions.ts
@@ -1,0 +1,55 @@
+import { auth } from "@/auth"
+import { prisma } from "@/lib/prisma"
+import { getCurrentUserId } from "./authActions"
+
+/**
+ * Toggles the like status of a target for the logged in user
+ */
+export const toggleLike = async (targetUserId: string, isLiked: boolean) => {
+  try {
+    const userId = await getCurrentUserId()
+
+    if (isLiked) {
+      prisma.like.delete({
+        where: {
+          sourceUserId_targetUserId: {
+            sourceUserId: userId,
+            targetUserId,
+          },
+        },
+      })
+    } else {
+      prisma.like.create({
+        data: { sourceUserId: userId, targetUserId },
+      })
+    }
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}
+
+/**
+ * @returns all target likes for the current user, ie, who has the current user liked
+ */
+export const fetchCurrentUserLikeIds = async () => {
+  try {
+    const userId = await getCurrentUserId()
+    const likes = await prisma.like.findMany({
+      where: {
+        sourceUserId: userId,
+      },
+      select: {
+        targetUserId: true,
+      },
+    })
+    console.log(
+      "#####🚀🚀🚀 ~ file: likeActions.ts:46 ~ fetchCurrentUserLikeIds ~ likes➡️➡️➡️",
+      likes
+    )
+    return likes.map(like => like.targetUserId)
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}

--- a/src/app/actions/likeActions.ts
+++ b/src/app/actions/likeActions.ts
@@ -1,6 +1,7 @@
 "use server"
 import { prisma } from "@/lib/prisma"
 import { getCurrentUserId } from "./authActions"
+import type { Member } from "@prisma/client"
 
 /**
  * Toggles the like status of a target for the logged in user
@@ -33,27 +34,6 @@ export const toggleLikeMember = async (
 }
 
 /**
- * @returns all target likes for the current user, ie, who has the current user liked
- */
-export const fetchTargetLikeIds = async () => {
-  try {
-    const userId = await getCurrentUserId()
-    const likes = await prisma.like.findMany({
-      where: {
-        sourceUserId: userId,
-      },
-      select: {
-        targetUserId: true,
-      },
-    })
-    return likes.map(like => like.targetUserId)
-  } catch (error) {
-    console.error(error)
-    throw error
-  }
-}
-
-/**
  * @param type whether the current user is the source, target or mutual target of likes
  * @param select whether to return the member Ids or members that meet the like type
  * @returns array of member Ids or members
@@ -61,7 +41,7 @@ export const fetchTargetLikeIds = async () => {
 export const fetchLikesForCurrentUser = async (
   type: "source" | "target" | "mutual",
   select: "id" | "member"
-) => {
+): Promise<string[] | Member[]> => {
   try {
     const userId = await getCurrentUserId()
 
@@ -152,8 +132,11 @@ export const fetchLikesForCurrentUser = async (
         }
 
       default:
-        break
+        throw new Error("fetchLikesForCurrentUser arguments not correct")
     }
-  } catch (error) {}
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
 }
 

--- a/src/app/actions/memberActions.ts
+++ b/src/app/actions/memberActions.ts
@@ -12,10 +12,6 @@ export const getMembers = async () => {
   if (!session?.user) return null
 
   try {
-    const random = Math.random()
-    if (random < 0.5) {
-      throw new Error("Just testing.......")
-    }
     return prisma.member.findMany({
       where: {
         NOT: {

--- a/src/app/lists/ListTabs.tsx
+++ b/src/app/lists/ListTabs.tsx
@@ -13,7 +13,6 @@ type ListTabProps = {
 export function ListTabs({ members, likeIds }: ListTabProps) {
   const pathName = usePathname()
   const router = useRouter()
-  const searchParams = useSearchParams()
 
   let items = [
     {
@@ -41,7 +40,7 @@ export function ListTabs({ members, likeIds }: ListTabProps) {
       aria-label="list member tabs"
       items={items}
       onSelectionChange={onTabSelection}
-      color="secondary"
+      color="secondary" 
     >
       {item => (
         <Tab key={item.id} title={item.label}>

--- a/src/app/lists/ListTabs.tsx
+++ b/src/app/lists/ListTabs.tsx
@@ -1,9 +1,10 @@
 "use client"
-import React from "react"
-import { Tabs, Tab} from "@nextui-org/react"
-import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import React, { useTransition } from "react"
+import { Tabs, Tab } from "@nextui-org/react"
+import { usePathname, useRouter } from "next/navigation"
 import MemberCard from "../members/memberCard"
 import type { Member } from "@prisma/client"
+import Loading from "@/components/Loading"
 
 type ListTabProps = {
   members: Member[]
@@ -13,6 +14,7 @@ type ListTabProps = {
 export function ListTabs({ members, likeIds }: ListTabProps) {
   const pathName = usePathname()
   const router = useRouter()
+  const [isPending, startTransition] = useTransition()
 
   let items = [
     {
@@ -30,9 +32,11 @@ export function ListTabs({ members, likeIds }: ListTabProps) {
   ]
 
   const onTabSelection = async (key: React.Key) => {
-    const params = new URLSearchParams()
-    params.set("type", key.toString())
-    router.replace(`${pathName}?${params}`)
+    startTransition(() => {
+      const params = new URLSearchParams()
+      params.set("type", key.toString())
+      router.replace(`${pathName}?${params}`)
+    })
   }
 
   return (
@@ -40,11 +44,14 @@ export function ListTabs({ members, likeIds }: ListTabProps) {
       aria-label="list member tabs"
       items={items}
       onSelectionChange={onTabSelection}
-      color="secondary" 
+      color="secondary"
+      defaultSelectedKey="source"
     >
       {item => (
         <Tab key={item.id} title={item.label}>
-          {members.length ? (
+          {isPending ? (
+            <Loading />
+          ) : members.length ? (
             <div className="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-8">
               {members.map(m => (
                 <MemberCard key={m.userId} member={m} likeIds={likeIds} />

--- a/src/app/lists/ListTabs.tsx
+++ b/src/app/lists/ListTabs.tsx
@@ -10,7 +10,7 @@ type ListTabProps = {
   likeIds: string[]
 }
 
-export const ListTabs: React.FC = ({ members, likeIds }: ListTabProps) => {
+export function ListTabs({ members, likeIds }: ListTabProps) {
   const pathName = usePathname()
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -37,21 +37,25 @@ export const ListTabs: React.FC = ({ members, likeIds }: ListTabProps) => {
   }
 
   return (
-    <div>
-      <Tabs
-        aria-label="list member tabs"
-        items={items}
-        onSelectionChange={onTabSelection}
-        color="secondary"
-      >
-        {item => (
-          <Tab key={item.id} title={item.label}>
-            {members.length
-              ? members.map(m => <li key={m.userId}>{m.userId}</li>)
-              : "No members meet the filter"}
-          </Tab>
-        )}
-      </Tabs>
-    </div>
+    <Tabs
+      aria-label="list member tabs"
+      items={items}
+      onSelectionChange={onTabSelection}
+      color="secondary"
+    >
+      {item => (
+        <Tab key={item.id} title={item.label}>
+          {members.length ? (
+            <div className="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-8">
+              {members.map(m => (
+                <MemberCard key={m.userId} member={m} likeIds={likeIds} />
+              ))}
+            </div>
+          ) : (
+            "No members meet the filter"
+          )}
+        </Tab>
+      )}
+    </Tabs>
   )
 }

--- a/src/app/lists/ListTabs.tsx
+++ b/src/app/lists/ListTabs.tsx
@@ -1,13 +1,19 @@
 "use client"
 import React from "react"
-import { Tabs, Tab, Card, CardBody, CardHeader } from "@nextui-org/react"
+import { Tabs, Tab} from "@nextui-org/react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import MemberCard from "../members/memberCard"
+import type { Member } from "@prisma/client"
 
-export function ListTabs() {
-  const pathname = usePathname()
+type ListTabProps = {
+  members: Member[]
+  likeIds: string[]
+}
+
+export const ListTabs: React.FC = ({ members, likeIds }: ListTabProps) => {
+  const pathName = usePathname()
   const router = useRouter()
   const searchParams = useSearchParams()
-  console.log("#####🚀🚀🚀 ~ file: ListTabs.tsx:10 ~ ListTabs ~ searchParams➡️➡️➡️", searchParams)
 
   let items = [
     {
@@ -16,7 +22,7 @@ export function ListTabs() {
     },
     {
       id: "target",
-      label: "Members that like me",  
+      label: "Members that like me",
     },
     {
       id: "mutual",
@@ -24,24 +30,25 @@ export function ListTabs() {
     },
   ]
 
-  const onTabSelection = (key: React.Key) => {
+  const onTabSelection = async (key: React.Key) => {
     const params = new URLSearchParams()
-      params.set("type", key.toString())
-      router.replace(`${pathname}?${params}`)
+    params.set("type", key.toString())
+    router.replace(`${pathName}?${params}`)
   }
+
   return (
     <div>
       <Tabs
         aria-label="list member tabs"
         items={items}
-        // selectedKey={pathname}
-        // defaultSelectedKey="source"
         onSelectionChange={onTabSelection}
+        color="secondary"
       >
         {item => (
           <Tab key={item.id} title={item.label}>
-            {/* member cards based on filter dummy content */}
-            <div>dummy content</div>
+            {members.length
+              ? members.map(m => <li key={m.userId}>{m.userId}</li>)
+              : "No members meet the filter"}
           </Tab>
         )}
       </Tabs>

--- a/src/app/lists/ListTabs.tsx
+++ b/src/app/lists/ListTabs.tsx
@@ -1,0 +1,50 @@
+"use client"
+import React from "react"
+import { Tabs, Tab, Card, CardBody, CardHeader } from "@nextui-org/react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+
+export function ListTabs() {
+  const pathname = usePathname()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  console.log("#####🚀🚀🚀 ~ file: ListTabs.tsx:10 ~ ListTabs ~ searchParams➡️➡️➡️", searchParams)
+
+  let items = [
+    {
+      id: "source",
+      label: "Members I Like",
+    },
+    {
+      id: "target",
+      label: "Members that like me",  
+    },
+    {
+      id: "mutual",
+      label: "Mutual likes",
+    },
+  ]
+
+  const onTabSelection = (key: React.Key) => {
+    const params = new URLSearchParams()
+      params.set("type", key.toString())
+      router.replace(`${pathname}?${params}`)
+  }
+  return (
+    <div>
+      <Tabs
+        aria-label="list member tabs"
+        items={items}
+        // selectedKey={pathname}
+        // defaultSelectedKey="source"
+        onSelectionChange={onTabSelection}
+      >
+        {item => (
+          <Tab key={item.id} title={item.label}>
+            {/* member cards based on filter dummy content */}
+            <div>dummy content</div>
+          </Tab>
+        )}
+      </Tabs>
+    </div>
+  )
+}

--- a/src/app/lists/page.tsx
+++ b/src/app/lists/page.tsx
@@ -1,10 +1,14 @@
 import React from "react"
 import { ListTabs } from "./ListTabs"
+import { fetchLikesForCurrentUser } from "../actions/likeActions"
 
-const ListsPage: React.FC = () => {
+const ListsPage: React.FC = async () => {
+  const likeIds = await fetchLikesForCurrentUser()
+  // need to access the query string to decide which members to fetch
+
   return (
     <div>
-      <ListTabs/>
+      <ListTabs />
     </div>
   )
 }

--- a/src/app/lists/page.tsx
+++ b/src/app/lists/page.tsx
@@ -1,14 +1,26 @@
 import React from "react"
 import { ListTabs } from "./ListTabs"
-import { fetchLikesForCurrentUser } from "../actions/likeActions"
+import {
+  fetchLikesForCurrentUser,
+  type LikeTypes,
+} from "../actions/likeActions"
+import type { Member } from "@prisma/client"
 
-const ListsPage: React.FC = async () => {
-  const likeIds = await fetchLikesForCurrentUser()
-  // need to access the query string to decide which members to fetch
+const ListsPage = async ({
+  searchParams,
+}: {
+  searchParams: { type: string }
+}) => {
+  const likeIds = (await fetchLikesForCurrentUser()) as string[]
+  const type = searchParams.type.toString() as LikeTypes
+  const membersToDisplay = (await fetchLikesForCurrentUser(
+    type,
+    "member"
+  )) as Member[]
 
   return (
     <div>
-      <ListTabs />
+      <ListTabs members={membersToDisplay} likeIds={likeIds} />
     </div>
   )
 }

--- a/src/app/lists/page.tsx
+++ b/src/app/lists/page.tsx
@@ -12,7 +12,7 @@ const ListsPage = async ({
   searchParams: { type: string }
 }) => {
   const likeIds = (await fetchLikesForCurrentUser()) as string[]
-  const type = searchParams.type.toString() as LikeTypes
+  const type = searchParams?.type?.toString() as LikeTypes
   const membersToDisplay = (await fetchLikesForCurrentUser(
     type,
     "member"

--- a/src/app/lists/page.tsx
+++ b/src/app/lists/page.tsx
@@ -1,7 +1,12 @@
 import React from "react"
+import { ListTabs } from "./ListTabs"
 
 const ListsPage: React.FC = () => {
-  return <div>ListsPage</div>
+  return (
+    <div>
+      <ListTabs/>
+    </div>
+  )
 }
 
 export default ListsPage

--- a/src/app/members/memberCard.tsx
+++ b/src/app/members/memberCard.tsx
@@ -1,19 +1,20 @@
+"use client"
 import LikeButton from "@/components/LikeButton"
 import { Card, CardFooter, Image } from "@nextui-org/react"
 import type { Member } from "@prisma/client"
 import { differenceInYears } from "date-fns"
 import Link from "next/link"
 import React from "react"
-import { toggleLike } from "../actions/likeActions"
 
 type memberCardProps = {
   member: Member
+  isLiked: boolean
 }
 
 /**
  * Used on /members page to display all members
  */
-export default function MemberCard({ member }: memberCardProps) {
+export default function MemberCard({ member, isLiked }: memberCardProps) {
   const age = differenceInYears(new Date(), member.dateOfBirth)
   return (
     <Card fullWidth as={Link} href={`/members/${member.userId}`}>
@@ -25,7 +26,7 @@ export default function MemberCard({ member }: memberCardProps) {
         className="aspect-square object-cover"
       />
       <div className="absolute top-[10px] right-[10px] z-10">
-        <LikeButton isLiked={false} targetUserId={member.userId} />
+        <LikeButton isLiked={isLiked} targetUserId={member.userId} />
       </div>
       <CardFooter className="absolute bottom-0 bg-black z-10 bg-dark-gradient">
         <div className="flex flex-col text-white">

--- a/src/app/members/memberCard.tsx
+++ b/src/app/members/memberCard.tsx
@@ -1,8 +1,10 @@
+import LikeButton from "@/components/LikeButton"
 import { Card, CardFooter, Image } from "@nextui-org/react"
 import type { Member } from "@prisma/client"
 import { differenceInYears } from "date-fns"
 import Link from "next/link"
 import React from "react"
+import { toggleLike } from "../actions/likeActions"
 
 type memberCardProps = {
   member: Member
@@ -22,6 +24,9 @@ export default function MemberCard({ member }: memberCardProps) {
         width={300}
         className="aspect-square object-cover"
       />
+      <div className="absolute top-[10px] right-[10px] z-10">
+        <LikeButton isLiked={false} targetUserId={member.userId} />
+      </div>
       <CardFooter className="absolute bottom-0 bg-black z-10 bg-dark-gradient">
         <div className="flex flex-col text-white">
           <span className="font-semibold">

--- a/src/app/members/memberCard.tsx
+++ b/src/app/members/memberCard.tsx
@@ -8,14 +8,15 @@ import React from "react"
 
 type memberCardProps = {
   member: Member
-  isLiked: boolean
+  likeIds: string[]
 }
 
 /**
  * Used on /members page to display all members
  */
-export default function MemberCard({ member, isLiked }: memberCardProps) {
+export default function MemberCard({ member, likeIds }: memberCardProps) {
   const age = differenceInYears(new Date(), member.dateOfBirth)
+  const isLiked = likeIds.includes(member.userId)
   return (
     <Card fullWidth as={Link} href={`/members/${member.userId}`}>
       <Image

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,16 +1,24 @@
-import { Button } from "@nextui-org/react"
 import React from "react"
 import { getMembers } from "../actions/memberActions"
+import { fetchTargetLikeIds } from "../actions/likeActions"
 import MemberCard from "./memberCard"
 
 const MembersPage: React.FC = async () => {
   const members = await getMembers()
+  const likeIds = await fetchTargetLikeIds()
   return (
     <div className="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-8">
-        {members &&
-          members.map(member => (
-            <MemberCard member={member} key={`${member.id}-member-card`} />
-          ))}
+      {members &&
+        members.map(member => {
+          const isLiked = likeIds.includes(member.userId)
+          return (
+            <MemberCard
+              member={member}
+              key={`${member.id}-member-card`}
+              isLiked={isLiked}
+            />
+          )
+        })}
     </div>
   )
 }

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -1,11 +1,14 @@
 import React from "react"
 import { getMembers } from "../actions/memberActions"
-import { fetchTargetLikeIds } from "../actions/likeActions"
+import {
+  fetchLikesForCurrentUser,
+} from "../actions/likeActions"
 import MemberCard from "./memberCard"
 
 const MembersPage: React.FC = async () => {
   const members = await getMembers()
-  const likeIds = await fetchTargetLikeIds()
+  // members that the current user has liked
+  const likeIds = await fetchLikesForCurrentUser("source", "id") as string[]
   return (
     <div className="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-8">
       {members &&

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -13,12 +13,11 @@ const MembersPage: React.FC = async () => {
     <div className="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-8">
       {members &&
         members.map(member => {
-          const isLiked = likeIds.includes(member.userId)
           return (
             <MemberCard
               member={member}
               key={`${member.id}-member-card`}
-              isLiked={isLiked}
+              likeIds={likeIds}
             />
           )
         })}

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -1,0 +1,31 @@
+"use client"
+import { toggleLike } from "@/app/actions/likeActions"
+import React from "react"
+import { AiFillHeart, AiOutlineHeart } from "react-icons/ai"
+
+type LikeButtonProp = {
+  isLiked: boolean
+  targetUserId: string
+}
+
+function LikeButton({ isLiked, targetUserId }: LikeButtonProp) {
+  const toggleButton = async () => {
+    await toggleLike(targetUserId, isLiked)
+  }
+  return (
+    <div
+      className="relative opacity-80 hover:opacity-100"
+      onClick={toggleButton}
+    >
+      <AiOutlineHeart size={28} className="fill-white" />
+      <AiFillHeart
+        size={24}
+        className={`absolute top-[2px] left-[2px] ${
+          isLiked ? "fill-rose-500" : "fill-neutral-500/70"
+        }`}
+      />
+    </div>
+  )
+}
+
+export default LikeButton

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -1,5 +1,6 @@
 "use client"
-import { toggleLike } from "@/app/actions/likeActions"
+import { toggleLikeMember } from "@/app/actions/likeActions"
+import { useRouter } from "next/navigation"
 import React from "react"
 import { AiFillHeart, AiOutlineHeart } from "react-icons/ai"
 
@@ -9,8 +10,14 @@ type LikeButtonProp = {
 }
 
 function LikeButton({ isLiked, targetUserId }: LikeButtonProp) {
-  const toggleButton = async () => {
-    await toggleLike(targetUserId, isLiked)
+  const router = useRouter()
+  const toggleButton = async (e: React.MouseEvent) => {
+    // stops the redirecting because this button is a child of MemberCard that acts like a link
+    e.preventDefault()
+    e.stopPropagation()
+    await toggleLikeMember(targetUserId, isLiked)
+    // refreshes matches page to reflect the lates like Ids
+    router.refresh()
   }
   return (
     <div

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+import { Spinner } from "@nextui-org/react"
+
+export default function Loading({ label }: { label?: string }) {
+  return (
+    <div className="fixed inset-0 flex justify-center items-center">
+      <Spinner
+        label={label || "Loading..."}
+        color="secondary"
+        labelColor="secondary"
+      />
+    </div>
+  )
+}

--- a/src/components/navbar/TopNav.tsx
+++ b/src/components/navbar/TopNav.tsx
@@ -29,7 +29,7 @@ export const TopNav = async () => {
         </div>
       </NavbarBrand>
       <NavbarContent>
-        <NavLink href="/members" label="Matches" />
+        <NavLink href="/members" label="Members" />
         <NavLink href="/lists" label="Lists" />
         <NavLink href="/messages" label="Messages" />
       </NavbarContent>


### PR DESCRIPTION
# User flow completed
- added 'like' & 'unlike' feature to member's display picture
- added 3 tabs under List section to display members that the user like, members that like the user, and mutual likes

![2024-07-05 13 11 35](https://github.com/hudson221b/nextmatch/assets/171628944/2a4bd98c-1263-4697-9f15-c66f88986be0)

# Tech details
## 1. Many-to-many relationship in database design. 
See this issue https://github.com/hudson221b/nextmatch/issues/4

## 2. Absolute positioning
- the "like" icon actually comprises of two carefully overlapped icons , one is outlined and the other one is filled. The filled one is conditionally colored to reflect the 'like" status

## 3. Join select and AND clause in Prisma
Selecting records from table B based on criteria and relation in table A.  Here our table A is the Like table. `sourceMember` is not a field in Like table, but we can select sourceMember from Member table based on its relation with Like
![Screenshot 2024-07-02 at 10 11 30 AM](https://github.com/hudson221b/nextmatch/assets/171628944/4369798d-677b-43a7-922f-85cdaafdc892)

### AND clause in Prisma
```
 const mutualLikes = await prisma.like.findMany({
            where: {
              AND: [
                { targetUserId: userId },
                { sourceUserId: { in: sourceLikeIds } },
              ],
            },
            select: {
              sourceUserId: true,
            },
          })
```
## 4. Integrating NextUI components with navigation
### Design: 
- under `/lists` path, we would like to display three tabs.
- clicking on each tab will set a query to the current path name. For each query, the app will make respective backend call to fetch members and display them as the tab content. 
- these queries are:   `type='source'` for members that I like, `type='target'`members that like me, and `type='mutual'` for members that have mutual like.

### Code implementation:
- query string will be set on the front-end, so `ListTab` will be a client-side component. The new URL will be set through `URLSearchParams` and `router` instance from `useRouter` hook from next/navigation
- we decide to fetch members in `page.tsx`- the parent of `ListTabs` instead of doing so in `ListTabs`. See reasons in tech details in point 6
- `page.tsx` needs to access the query string to determine which type of members to fetch. How will a server-side component receive search params from a URL?

![Screenshot 2024-07-02 at 4 19 57 PM](https://github.com/hudson221b/nextmatch/assets/171628944/b936bd2f-515e-48e5-90ac-6a11b944ab37)

## 5. `router.replace vs. router.push`
As the name suggests, replace replaces an existing history entry, push adds a new history entry. Based on this understanding, replace:

- updates current page’s url
- re-renders page with the new query string

This means the user won’t be able go “back” to the previous query string.

## 6. Async operations in a client-component
In the app under `/lists` path, the navigation tabs need a different set of members data to display for each tab.  Should we fetch this members data in `ListTabs` component (client-side), where we determine the `selectedTabKey` through UI framework then fetch data, or should we fetch in `page.tsx` (server-side) and pass the members data as props to `ListTabs`?

Server-side is a much better solution since the server-side component can be async and perform a lot of server actions with ease. Passing down fetched data will be easy too.

## 7. `useTransition` React hook
- when switching between tabs, we see a flickering of old member pictures before new member pictures are rendered on the new url
- query string change won’t trigger the conventional `loading.tsx` in next.js because it’s not switching different pages
- to solve the stale members card flickering problem, we utilize this hook to display a loading spinner when re-render happens

# Pitfalls
### 1. Runtime error: `PrismaClient is unable to run in this browser environment, or has been bundled for the browser (running in unknown)`
if we import prisma client in a server actions file that has no “use server” on top, this error will throw.

### 2. Missing await in an async function (Prisma quirk)
In a server action, I accidentally missed the `await` keyword in front of an async operation

![Screenshot 2024-07-01 at 5 03 26 PM](https://github.com/hudson221b/nextmatch/assets/171628944/58891964-d45e-49a8-a8ff-0020517b01b9)


```tsx
function LikeButton({ isLiked, targetUserId }: LikeButtonProp) {
  const toggleButton = async () => {
    await toggleLikeMember(targetUserId, isLiked)
  }
  return (
    <div
      className="relative opacity-80 hover:opacity-100"
      onClick={toggleButton}
    >
```

Normally, the promise would eventually resolve. It may cause some racing conditions or delays, but it would be fulfilled. However, in the app, clicking the button never complete the prisma operation. Why is that? 

This is a Prisma quirk or 'feature' explained  in their [doc](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/introduction#4-use-prisma-client-to-send-queries-to-your-database)
![Screenshot 2024-07-01 at 5 08 39 PM](https://github.com/hudson221b/nextmatch/assets/171628944/5ca855f9-daf1-4531-bc7c-a551c2a4faff)

### 3. How to prevent link redirect?
In our app, clicking the heart in the upper right corner of a member's image will like or unlike him/her. However, the member's picture also serves as a link (because of `as={Link}` property), clicking anywhere in the picture will take us to the member's detail page. We do not want the redirection when clicking the like icon. 

First I thought: stopping the clicking event bubbling up to the parent would solve the problem. It didn't. 

True that  **`event.stopPropagation()`** in an event handler stops the event from bubbling up to parent elements, but it does not prevent the default action associated with that event. In the context of a link (**`<a>`** tag), the default action is to navigate to the URL specified in the **`href`** attribute. So we need `event.preventDefault` as well. 
