### PR TITLE
Section8 - part 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "react-hook-form": "^7.51.5",
         "react-icons": "^5.2.1",
         "react-toastify": "^10.0.5",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zustand": "^4.5.4"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -8123,6 +8124,14 @@
         }
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8381,6 +8390,33 @@
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.4.tgz",
+      "integrity": "sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-hook-form": "^7.51.5",
     "react-icons": "^5.2.1",
     "react-toastify": "^10.0.5",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/src/app/api/pusher-auth/route.ts
+++ b/src/app/api/pusher-auth/route.ts
@@ -3,13 +3,27 @@ import { pusherServer } from "@/lib/pusher"
 
 export async function POST(req: Request) {
   try {
+    // check if a user has logged in
     const session = await auth()
     const userId = session?.user?.id
-    
+
     if (!userId) {
       return Response.json({ message: "Not authorized", status: 403 })
     }
-    const body = await req.json()
+
+    // parse request body
+    let body
+    const contentType = req.headers.get("content-type")
+    if (contentType?.includes("application/json")) {
+      body = await req.json()
+    } else if (contentType?.includes("application/x-www-form-urlencoded")) {
+      const text = await req.text()
+      body = Object.fromEntries(new URLSearchParams(text))
+    } else {
+      body = await req.text() 
+    }
+
+    // auth and send response
     const socketId = body.socket_id
     const channel = body.channel_name
     const presenceData = {
@@ -21,6 +35,13 @@ export async function POST(req: Request) {
       presenceData
     )
 
-    return Response.json(authResponse)
-  } catch (error) {}
+    return Response.json(authResponse, { status: 200 })
+  } catch (error) {
+    console.error("Presence channel authorization error:", error)
+    return Response.json({
+      message: "Error during authorizing Pusher request",
+      error: error instanceof Error ? error.message : String(error),
+      status: 500,
+    })
+  }
 }

--- a/src/app/api/pusher-auth/route.ts
+++ b/src/app/api/pusher-auth/route.ts
@@ -1,0 +1,26 @@
+import { auth } from "@/auth"
+import { pusherServer } from "@/lib/pusher"
+
+export async function POST(req: Request) {
+  try {
+    const session = await auth()
+    const userId = session?.user?.id
+    
+    if (!userId) {
+      return Response.json({ message: "Not authorized", status: 403 })
+    }
+    const body = await req.json()
+    const socketId = body.socket_id
+    const channel = body.channel_name
+    const presenceData = {
+      user_id: userId,
+    }
+    const authResponse = pusherServer.authorizeChannel(
+      socketId,
+      channel,
+      presenceData
+    )
+
+    return Response.json(authResponse)
+  } catch (error) {}
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next"
 import "./globals.css"
 import { UIProviders } from "@/components/Providers"
-import { ToastContainer } from "react-toastify"
-import "react-toastify/ReactToastify.css"
+import TopNav from "@/components/navbar/TopNav"
 
 export const metadata: Metadata = {
   title: "NextMatch",
@@ -14,13 +13,12 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-
   return (
     <html lang="en">
       <body>
         <UIProviders>
-          <main className="p-10 container mx-auto">{children}</main>
-          <ToastContainer position="bottom-right"/>
+          <TopNav />
+          <main className="container mx-auto">{children}</main>
         </UIProviders>
       </body>
     </html>

--- a/src/app/members/[memberId]/chat/page.tsx
+++ b/src/app/members/[memberId]/chat/page.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import ChatForm from "./ChatForm"
 import { getChatMessages } from "@/app/actions/messageActions"
 import { getCurrentUserId } from "@/app/actions/authActions"
-import { getChannelName } from "@/lib/util"
+import { generateChatChannelName } from "@/lib/util"
 import ChatMessages from "./ChatMessages"
 
 export default async function ChatPage({
@@ -16,7 +16,7 @@ export default async function ChatPage({
   const initialMessages = await getChatMessages(memberId)
   const userId = await getCurrentUserId()
 
-  const channelName = getChannelName(userId, memberId)
+  const channelName = generateChatChannelName(userId, memberId)
 
   const body = (
     <div className="overflow-y-auto w-full h-full">

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,11 +1,16 @@
+"use client"
+
 import { NextUIProvider } from "@nextui-org/react"
 import React, { type ReactNode } from "react"
-import TopNav from "./navbar/TopNav"
+import { usePresenceChannel } from "@/hooks/usePresenceChannel"
+import { ToastContainer } from "react-toastify"
+import "react-toastify/ReactToastify.css"
 
 export const UIProviders = ({ children }: { children: ReactNode }) => {
+  usePresenceChannel()
   return (
     <NextUIProvider>
-      <TopNav />
+      <ToastContainer position="bottom-right" />
       {children}
     </NextUIProvider>
   )

--- a/src/hooks/presenceStore.ts
+++ b/src/hooks/presenceStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand"
+import { devtools } from "zustand/middleware"
+
+type PresenceState = {
+  members: string[]
+  addMember: (id: string) => void
+  removeMember: (id: string) => void
+  setMembers: (ids: string[]) => void
+}
+
+/**
+ * Creates a global presence store to keep track of users connected to the app.
+ */
+const usePresenceStore = create<PresenceState>()(
+  devtools(
+    set => ({
+      members: [],
+      addMember: id => set(state => ({ members: [...state.members, id] })),
+      removeMember: id =>
+        set(state => ({
+          members: state.members.filter(member => member !== id),
+        })),
+      setMembers: ids => set({ members: ids }),
+    }),
+    {
+      name: "presence_store",
+    }
+  )
+)

--- a/src/hooks/usePresenceChannel.ts
+++ b/src/hooks/usePresenceChannel.ts
@@ -1,3 +1,5 @@
+// "use client"
+
 import { useEffect, useRef } from "react"
 import { usePresenceStore } from "./useStores"
 import type { Channel, Members } from "pusher-js"
@@ -7,6 +9,8 @@ import { pusherClient } from "@/lib/pusher"
  * Changes in pusher presence channel will update the presence store
  */
 export const usePresenceChannel = () => {
+
+  // we would like these three methods to stay the same when members state changes
   const { add, remove, set } = usePresenceStore(state => ({
     add: state.addMember,
     remove: state.removeMember,

--- a/src/hooks/usePresenceChannel.ts
+++ b/src/hooks/usePresenceChannel.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from "react"
+import { usePresenceStore } from "./useStores"
+import type { Channel, Members } from "pusher-js"
+import { pusherClient } from "@/lib/pusher"
+
+/**
+ * Changes in pusher presence channel will update the presence store
+ */
+export const usePresenceChannel = () => {
+  const { add, remove, set } = usePresenceStore(state => ({
+    add: state.addMember,
+    remove: state.removeMember,
+    set: state.setMembers,
+  }))
+
+  // To prevent more than once channel subscription in useEffect (useEffect running twice in React strict mode in development), we need to assign channel object to a ref
+  const channelRef = useRef<Channel | null>(null)
+
+  useEffect(() => {
+    if (!channelRef.current) {
+      channelRef.current = pusherClient.subscribe("presence-online-members")
+
+      // pusher:subscription_succeeded is one of the pre-defined events
+      // see members iterator doc here https://pusher.com/docs/channels/using_channels/presence-channels/#the-members-parameter
+      channelRef.current.bind(
+        "pusher:subscription_succeeded",
+        (members: Members) => {
+          console.log("#####🚀🚀🚀 ~ useEffect ~ members👉👉", members)
+          // upon successful subscription, set members in store using the members param from this pusher callback
+        }
+      )
+
+      // the member object has two properties: id and info; both are set during server authorization
+      channelRef.current.bind(
+        "pusher:member_added",
+        (member: Record<string, any>) => {
+          add(member.id)
+        }
+      )
+
+      channelRef.current.bind(
+        "pusher:member_removed",
+        (member: Record<string, any>) => {
+          remove(member.id)
+        }
+      )
+    }
+
+    return () => {
+      if (channelRef.current) {
+        channelRef.current.unsubscribe()
+
+        channelRef.current.unbind("pusher:subscription_succeeded")
+        channelRef.current.unbind("pusher:member_added")
+        channelRef.current.unbind("pusher:member_removed")
+      }
+    }
+  }, [add, remove])
+}

--- a/src/hooks/usePresenceChannel.ts
+++ b/src/hooks/usePresenceChannel.ts
@@ -7,7 +7,6 @@ import { pusherClient } from "@/lib/pusher"
  * Subscribes a logged in user to the presence channel immediately. It is called in the most top level client component - UIProviders. After successful subscription, sets redux state members to the channel members
  */
 export const usePresenceChannel = () => {
-  // we would expect the three methods not changed by members state in the store
   const { add, remove, set } = usePresenceStore(state => ({
     add: state.addMember,
     remove: state.removeMember,
@@ -52,7 +51,6 @@ export const usePresenceChannel = () => {
 
     return () => {
       if (channelRef.current && channelRef.current.subscribed) {
-        console.log("ref is not null, cleaning up", channelRef.current)
         channelRef.current.unbind_all()
         pusherClient.unsubscribe("presence-online-members")
       }

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -1,3 +1,7 @@
+/**
+ * This file exports all zustand stores
+ */
+
 import { create } from "zustand"
 import { devtools } from "zustand/middleware"
 
@@ -11,7 +15,7 @@ type PresenceState = {
 /**
  * Creates a global presence store to keep track of users connected to the app.
  */
-const usePresenceStore = create<PresenceState>()(
+export const usePresenceStore = create<PresenceState>()(
   devtools(
     set => ({
       members: [],

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -15,6 +15,10 @@ if (!global.pusherClient) {
     {
       cluster: process.env.NEXT_PUBLIC_PUSHER_CLUSTER!,
       forceTLS: true,
+      channelAuthorization: {
+        endpoint: "/api/pusher-auth",
+        transport: "ajax",
+      },
     }
   )
 }

--- a/src/lib/pusher.ts
+++ b/src/lib/pusher.ts
@@ -10,6 +10,7 @@ declare global {
 }
 
 if (!global.pusherClient) {
+  PusherClient.logToConsole = true
   global.pusherClient = new PusherClient(
     process.env.NEXT_PUBLIC_PUSHER_APP_KEY!,
     {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -3,7 +3,7 @@ import {  formatDistanceToNow } from "date-fns"
 /**
  * Creates a unique channel name between the current user and the recipient. It's alphabetically sorted so to ensure only one channel name between two users.
  */
-export function getChannelName(userId: string, recipientId: string) {
+export function generateChatChannelName(userId: string, recipientId: string) {
   return userId > recipientId
     ? `${recipientId}-${userId}`
     : `${userId}-${recipientId}`


### PR DESCRIPTION
This PR provides the foundation for the feature "showing which members are online" using a Pusher presence channel and a redux store.

## Tech details
- Presence channel is a type of private channels. To subscribe to a presence channel, server needs to authorize the request. 
- A brief process illustration can be found [here](https://pusher.com/docs/channels/server_api/authorizing-users/#channel-subscription-authorization)
- Adopted `zustand` as the new state management tool 

## Takeaways
### 1. You CANNOT use a server component directly within a client component.

Because server components are rendered on the server and client components are rendered on the client side.

This is wrong
```jsx
"use client"

import { NextUIProvider } from "@nextui-org/react"
import React, { type ReactNode } from "react"
import TopNav from "./navbar/TopNav"
import { usePresenceChannel } from "@/hooks/usePresenceChannel"

export const UIProviders = ({ children }: { children: ReactNode }) => {
  usePresenceChannel()
  return (
    <NextUIProvider>
      <TopNav /> // TopNav is a server component
      {children}
    </NextUIProvider>
  )
}
```

You’ll get compiling error: 

Error: Server Functions cannot be called during initial render. This would create a fetch waterfall. Try to use a Server Component to pass data to Client Components instead.
at TopNav (./src/components/navbar/TopNav.tsx:31:116)

**Solution:**
Move `TopNav` out from UIProviders and place it in layout.ts

### 2. A request body is not necessarily in JSON format
**The problem:**

I encountered unsuccessful Pusher channel subscription. The error message indicates that it could be from the Pusher auth API endpoint setup

![Screenshot 2024-08-12 at 4 48 47 PM](https://github.com/user-attachments/assets/7fc16c70-a732-4e7a-998d-7e79eaa54200)

This is the endpoint code:

```js
// app/api/pusher-auth.ts

export async function POST(req: Request) {
  try {
    const session = await auth()
    const userId = session?.user?.id

    if (!userId) {
      return Response.json({ message: "Not authorized", status: 403 })
    }
    const body = await req.json()

    const socketId = body.socket_id
    const channel = body.channel_name
    const presenceData = {
      user_id: userId,
    }
    const authResponse = pusherServer.authorizeChannel(
      socketId,
      channel,
      presenceData
    )

    return Response.json(authResponse, { status: 200 })
  } catch (error) {
    console.error("Presence channel authorization error:", error)
    return Response.json({
      message: "Internal server error",
      error: error instanceof Error ? error.message : String(error),
      status: 500,
    })
  }
}
```

**Debugging:**

Inspecting the auth request from Pusher, 
![Screenshot 2024-08-12 at 4 52 53 PM](https://github.com/user-attachments/assets/cfe183a1-c4e1-4fcc-9a3a-4854fb1945d5)

after we clicked “view source”
![Screenshot 2024-08-12 at 4 57 48 PM](https://github.com/user-attachments/assets/a673878e-7bcd-4871-bad6-c91a69d6897f)

we found out that Pusher’s request body is not in JSON format but in URL_encoded format. Hence  in the code: `req.json()` does not work

**Solution:**

To read body as an accessible object, we need to parse it like this
```js
 const text = await req.text();
 body = Object.fromEntries(new URLSearchParams(text))
 ;
 // body now is accessible using the dot notation
```

### 3. A ref's latest value in useEffect
This is probably some basic React knowledge. In short, If a ref is set within a useEffect, then in the cleanup function, it has access to the latest value of that ref. 

## Biggest challenge I had during part 2
**Conclusion first:**
Pusher subscription is asynchronous but this fact is not labeled as such in their docs and not indicated in the example code. When you have both subscribe and unsubscribe operations within the same block of code, you need to watch out for their  unpredictable racing condition, because it can bring you unwanted result or unsuccessful subscription.

**The Problem**

Background:
- we would like to built a custom hook that subscribes a logged in user to a presence channel as soon as they log in
- this custom hook is called in the top most level of a client component in our app
- we have a global Pusher client instance, initialized when the app launches on the client end
- we decide to put subscription and binding operations inside a useEffect
- as we know, useEffect will intentionally run twice in React strict mode during development. To prevent the app from subscribing to the same channel multiple times, which is known to cause interesting and problematic behavior, we decide to assign the presence channel to a ref
- we decide to clean the subscription and bindings in the cleanup function of useEffect

Code:
```jsx
export const usePresenceChannel = () => {
  
  const { add, remove, set } = usePresenceStore(state => ({
    add: state.addMember,
    remove: state.removeMember,
    set: state.setMembers,
  }))

 
  const channelRef = useRef<Channel | null>(null)

  useEffect(() => {
    if (!pusherClient) {
      console.error("Pusher client is not initialized")
      return
    }

    if (!channelRef.current) {
      console.log("ref is null, start subscribing")

      channelRef.current = pusherClient.subscribe("presence-online-members")
      console.log("after subscribe", channelRef.current)

      channelRef.current.bind(
        "pusher:subscription_succeeded",
        (members: Members) => {
          console.log("#####🚀🚀🚀 ~ useEffect ~ members👉👉", members)
          set(Object.keys(members.members))
        }
      )

      channelRef.current.bind(
        "pusher:member_added",
        (member: Record<string, any>) => {
          add(member.id)
        }
      )

      channelRef.current.bind(
        "pusher:member_removed",
        (member: Record<string, any>) => {
          remove(member.id)
        }
      )
    } else {
      console.log("ref is not null, doing nothing", channelRef.current)
    }

     return () => {
       if (channelRef.current) {
         console.log("ref is not null, cleaning up", channelRef.current);
         channelRef.current.unbind_all()
         pusherClient.unsubscribe("presence-online-members")
         console.log("after unsubscribe", channelRef.current);
       }
    }
  }, [add, remove, set])
}
```
With above code, when I open a new tab and access the app, I got the following logs in the browser and the following websocket network requests
![Screenshot 2024-08-13 at 1 33 28 PM](https://github.com/user-attachments/assets/53dffa49-a619-4592-b9f5-742e253e3773)

![Screenshot 2024-08-13 at 12 59 46 PM](https://github.com/user-attachments/assets/7e6bcf43-8ef5-4917-a759-acf186f32535)

Where is the subscribe request and the following subscription_succeeded event binding???

**Debugging and analysis**

Based on my console logs, I map out the timeline of the two render cycles and the channel states in the first render:

![长图拼接大师](https://github.com/user-attachments/assets/602fe030-e0dc-45d4-88df-fc82cd718fe7)

It looks like the channel, after we call `pusherClient.subscribe`, is not subscribed. I refreshed the page several times. Among these refreshed logs, I noticed that sometimes `channel.subscriptionCancelled` is true.

After all other checks and asking Claude, I suspect that, in the cleanup function, the unsubscribe is invoked before the channel can finish subscribing. So at the end of first render: channel is created, assigned to a ref, but subscription is not successful. 

Hence during the second render, no action was taken. No subscription from start to end, because the first attempt was killed in first render, and no attempt was made in second render because ref.current is not null anymore. 

Why did unsubscribe finish before subscribe is unclear. It’s possible that the communication with Pusher service has interesting race conditions.

To prove my theory, I commented out the cleanup function. Without the unsubscribe, subscription was successful almost instantly.
```jsx
// return () => {
    //   if (channelRef.current) {
    //     console.log("ref is not null, cleaning up", channelRef.current)
    //     channelRef.current.unbind_all()
    //     pusherClient.unsubscribe("presence-online-members")
    //     console.log("after unsubscribe", channelRef.current)
    //   }
    // }
```
![Screenshot 2024-08-13 at 3 55 08 PM](https://github.com/user-attachments/assets/5794f0b2-3cc8-4266-9dd6-7132d674b73b)

**Solution**

Now we know that the cleanup creates a weird racing condition that interferes with subscribing to a channel before the process finishes. At the same time, we do need this cleanup when app is closed. How do we keep the unsubscribe AND stop it from interfering our initial subscribing during initial render? 

The solution is simple. We add another check on the channel status, to make sure we only unsubscribe a  channel when we know it’s subscribed already.
```jsx
return () => {
      if (channelRef.current && channelRef.current.subscribed) {
      ...
      }
 }
```
After adding this condition, I’m finally able to subscribe to the presence channel and see successful binding events every time.