### PR TITLE
Section9 part2

### DIFF
--- a/src/app/NextUIOverride.module.css
+++ b/src/app/NextUIOverride.module.css
@@ -1,0 +1,3 @@
+.footer {
+  overflow: unset;
+}

--- a/src/app/actions/memberActions.ts
+++ b/src/app/actions/memberActions.ts
@@ -39,7 +39,7 @@ export const getMembers = async ({
   // filter on gender
   const genderArray = gender.split("&")
 
-  const skip = parseInt(pageNumber) - 1 * parseInt(pageSize)
+  const skip = (parseInt(pageNumber) - 1) * parseInt(pageSize)
 
   try {
     const totalCount = await prisma.member.count({

--- a/src/app/actions/memberActions.ts
+++ b/src/app/actions/memberActions.ts
@@ -8,36 +8,44 @@ import {
 } from "@/lib/zod-schemas/member-edit-schema"
 import type { Member, Photo } from "@prisma/client"
 import { getCurrentUserId } from "./authActions"
-import type { ActionResult, MemberFilters } from "@/types"
+import type {
+  ActionResult,
+  GetMembersParams,
+  PaginationResponse,
+} from "@/types"
 import { cloudinary } from "@/lib/cloudinary"
 import { addYears } from "date-fns"
 
 /**
  * get all members except oneself after login
  */
-export const getMembers = async (searchParams: { [key: string]: string }) => {
-  const session = await auth()
-  if (!session?.user) return null
+export const getMembers = async ({
+  ageRange = "18-100",
+  orderBy = "updated",
+  gender = "female&male",
+  pageNumber = "1",
+  pageSize = "12",
+}: GetMembersParams): Promise<PaginationResponse<Member>> => {
+  const userId = await getCurrentUserId()
 
   // filter on age
-  const ageRange = (searchParams.ageRange || "18-100").split("-")
+  const [minAge, maxAge] = ageRange.split("-")
   const currentDate = new Date()
   // the upper bound of DoB, no later than this date
-  const maxDoB = addYears(currentDate, -ageRange[0])
+  const maxDoB = addYears(currentDate, -minAge)
   // the lower bound of DoB, no earlier than this date
-  const minDoB = addYears(currentDate, -ageRange[1] - 1)
-
-  // sort result
-  const orderBySelector = searchParams.orderBy || "updated"
+  const minDoB = addYears(currentDate, -maxAge - 1)
 
   // filter on gender
-  const selectedGender = searchParams.gender?.split("&") || ["female", "male"]
+  const genderArray = gender.split("&")
+
+  const skip = parseInt(pageNumber) - 1 * parseInt(pageSize)
 
   try {
-    return prisma.member.findMany({
+    const totalCount = await prisma.member.count({
       where: {
         NOT: {
-          userId: session.user.id,
+          userId: userId,
         },
         AND: [
           {
@@ -51,12 +59,38 @@ export const getMembers = async (searchParams: { [key: string]: string }) => {
             },
           },
           {
-            gender: { in: selectedGender },
+            gender: { in: genderArray },
           },
         ],
       },
-      orderBy: { [orderBySelector]: "desc" },
     })
+    const members = await prisma.member.findMany({
+      where: {
+        NOT: {
+          userId,
+        },
+        AND: [
+          {
+            dateOfBirth: {
+              gte: minDoB,
+            },
+          },
+          {
+            dateOfBirth: {
+              lte: maxDoB,
+            },
+          },
+          {
+            gender: { in: genderArray },
+          },
+        ],
+      },
+      skip,
+      take: parseInt(pageSize),
+      orderBy: { [orderBy]: "desc" },
+    })
+
+    return { items: members, totalCount }
   } catch (error) {
     console.error(error)
     throw error

--- a/src/app/actions/memberActions.ts
+++ b/src/app/actions/memberActions.ts
@@ -25,6 +25,7 @@ export const getMembers = async ({
   gender = "female&male",
   pageNumber = "1",
   pageSize = "12",
+  hasPhotos = "false",
 }: GetMembersParams): Promise<PaginationResponse<Member>> => {
   const userId = await getCurrentUserId()
 
@@ -38,6 +39,9 @@ export const getMembers = async ({
 
   // filter on gender
   const genderArray = gender.split("&")
+
+  // filter on photos
+  const hasImage = hasPhotos === "true" ? { image: { not: null } } : {}
 
   const skip = (parseInt(pageNumber) - 1) * parseInt(pageSize)
 
@@ -61,6 +65,7 @@ export const getMembers = async ({
           {
             gender: { in: genderArray },
           },
+          hasImage,
         ],
       },
     })
@@ -83,6 +88,7 @@ export const getMembers = async ({
           {
             gender: { in: genderArray },
           },
+          hasImage,
         ],
       },
       skip,

--- a/src/app/lists/ListTabs.tsx
+++ b/src/app/lists/ListTabs.tsx
@@ -4,7 +4,7 @@ import { Tabs, Tab } from "@nextui-org/react"
 import { usePathname, useRouter } from "next/navigation"
 import MemberCard from "../members/memberCard"
 import type { Member } from "@prisma/client"
-import Loading from "@/components/Loading"
+import { LoadingComponent } from "@/components/Loading"
 
 type ListTabProps = {
   members: Member[]
@@ -50,7 +50,7 @@ export function ListTabs({ members, likeIds }: ListTabProps) {
       {item => (
         <Tab key={item.id} title={item.label}>
           {isPending ? (
-            <Loading />
+            <LoadingComponent />
           ) : members.length ? (
             <div className="mt-10 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-8">
               {members.map(m => (

--- a/src/app/members/[memberId]/ChatPage.module.css
+++ b/src/app/members/[memberId]/ChatPage.module.css
@@ -1,3 +1,0 @@
-.footer {
-    overflow: unset;
-}

--- a/src/app/members/[memberId]/layout.tsx
+++ b/src/app/members/[memberId]/layout.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation"
 import React, { type ReactNode } from "react"
 import MemberSidebar from "../memberSidebar"
 import { Card } from "@nextui-org/react"
-import styles from "./ChatPage.module.css"
+import styles from "../../NextUIOverride.module.css"
 
 /**
  * This layout component receives a prop object containing two properties: 1. children: which are React elements returned from page.tsx under route /members/memberId.

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -5,13 +5,14 @@ import {
 import MemberCard from "./memberCard"
 import PaginationComponent from "@/components/PaginationComponent"
 import EmptyResult from "@/components/EmptyResult"
+import type { GetMembersParams } from "@/types"
 
 const MembersPage = async ({
   searchParams,
 }: {
-  searchParams: { [key: string]: string }
+  searchParams: GetMembersParams
 }) => {
-  const members = await getMembers(searchParams)
+  const { items: members, totalCount } = await getMembers(searchParams)
 
   // members that the current user has liked
   const likeIds = (await fetchLikesForCurrentUser("source", "id")) as string[]
@@ -32,7 +33,7 @@ const MembersPage = async ({
             )
           })}
       </div>
-      <PaginationComponent />
+      <PaginationComponent totalCount={totalCount} />
     </>
   )
 }

--- a/src/app/messages/MessageSidebar.tsx
+++ b/src/app/messages/MessageSidebar.tsx
@@ -3,7 +3,7 @@
 import { useMessagesStore } from "@/hooks/useStores"
 import { Chip } from "@nextui-org/react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { GoInbox } from "react-icons/go"
 import { MdOutlineOutbox } from "react-icons/md"
 
@@ -15,6 +15,9 @@ export default function MessageSidebar() {
   const [selected, setSelected] = useState<string>(
     searchParams.get("container") || "inbox"
   )
+  useEffect(() => {
+    setSelected(searchParams.get("container") || "inbox")
+  }, [searchParams])
 
   const items = [
     {

--- a/src/app/messages/MessageTable.tsx
+++ b/src/app/messages/MessageTable.tsx
@@ -8,32 +8,40 @@ import {
   TableRow,
   TableCell,
   Card,
+  CardFooter,
+  Button,
+  CardBody,
 } from "@nextui-org/react"
 import { useRouter } from "next/navigation"
-import React, { useCallback, useEffect, useMemo, type Key } from "react"
-import { deleteMessageById } from "../actions/messageActions"
+import React, { useCallback, useEffect, useMemo, useRef, type Key } from "react"
 import MesageTableCell from "./MesageTableCell"
 import { useMessagesStore } from "@/hooks/useStores"
+import { getMessagesByContainer } from "../actions/messageActions"
+import styles from "../NextUIOverride.module.css"
 
 export default function MessageTable({
   container,
   initialMessages, // messages fetched from database
+  cursor,
 }: {
-  container: string
+  container: "inbox" | "outbox"
   initialMessages: MessageDTO[]
+  cursor: string | undefined
 }) {
+  const cursorRef = useRef(cursor)
   const router = useRouter()
   const isInbox = useMemo(() => container === "inbox", [container])
 
-  const { set, messages } = useMessagesStore()
+  const { set, messages, resetMessages } = useMessagesStore()
 
   useEffect(() => {
     set(initialMessages)
+    cursorRef.current = cursor
 
     return () => {
-      set([])
+      resetMessages()
     }
-  }, [initialMessages, set])
+  }, [initialMessages, resetMessages, set, cursor])
 
   const columns = useMemo(
     () => [
@@ -62,35 +70,68 @@ export default function MessageTable({
     [isInbox, messages, router]
   )
 
+  const loadMore = useCallback(async () => {
+    if (cursorRef.current) {
+      const { messages, nextCursor } = await getMessagesByContainer(
+        container,
+        cursorRef.current
+      )
+      cursorRef.current = nextCursor
+
+      set(messages)
+    }
+  }, [container, set])
+
   return (
-    <Card className="h-[80vh] overflow-auto">
-      <Table
-        aria-label="messages table"
-        selectionMode="single"
-        onRowAction={handleRowCLick}
-        shadow="none"
-      >
-        <TableHeader columns={columns}>
-          {column => <TableColumn key={column.key}>{column.label}</TableColumn>}
-        </TableHeader>
-        <TableBody items={messages}>
-          {item => (
-            <TableRow key={item.id}>
-              {columnKey => (
-                <TableCell
-                  className={`${!item.dateRead && isInbox && "font-semibold"}`}
-                >
-                  <MesageTableCell
-                    item={item}
-                    columnKey={columnKey as keyof MessageDTO}
-                    isInbox={isInbox}
-                  />
-                </TableCell>
-              )}
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
+    <Card
+      className="h-[80vh]"
+      classNames={{
+        footer: styles.footer,
+      }}
+    >
+      <CardBody className="overflow-auto">
+        <Table
+          aria-label="messages table"
+          selectionMode="single"
+          onRowAction={handleRowCLick}
+          shadow="none"
+        >
+          <TableHeader columns={columns}>
+            {column => (
+              <TableColumn key={column.key}>{column.label}</TableColumn>
+            )}
+          </TableHeader>
+          <TableBody items={messages}>
+            {item => (
+              <TableRow key={item.id}>
+                {columnKey => (
+                  <TableCell
+                    className={`${
+                      !item.dateRead && isInbox && "font-semibold"
+                    }`}
+                  >
+                    <MesageTableCell
+                      item={item}
+                      columnKey={columnKey as keyof MessageDTO}
+                      isInbox={isInbox}
+                    />
+                  </TableCell>
+                )}
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </CardBody>
+      <CardFooter className="justify-end">
+        <Button
+          color="secondary"
+          isDisabled={!cursorRef.current}
+          onClick={loadMore}
+          className="mr-8"
+        >
+          {cursorRef.current ? "Load more" : "No more messages"}
+        </Button>
+      </CardFooter>
     </Card>
   )
 }

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -8,7 +8,7 @@ const MessagesPage = async ({
   searchParams: { container: string }
 }) => {
   const isOutbox = searchParams.container === "outbox"
-  const messages = isOutbox
+  const { messages, nextCursor } = isOutbox
     ? await getMessagesByContainer("outbox")
     : await getMessagesByContainer("inbox")
 
@@ -21,6 +21,7 @@ const MessagesPage = async ({
         <MessageTable
           initialMessages={messages}
           container={isOutbox ? "outbox" : "inbox"}
+          cursor={nextCursor}
         />
       </div>
     </div>

--- a/src/components/PaginationComponent.tsx
+++ b/src/components/PaginationComponent.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { usePaginationStore } from "@/hooks/useStores"
+import usePagination from "@/hooks/usePagination"
 import { Pagination } from "@nextui-org/react"
 import { useEffect, useMemo } from "react"
 
@@ -9,7 +9,7 @@ export default function PaginationComponent({
   totalCount: number
 }) {
   const { pagination, setTotalCount, setPageNumber, setPageSize } =
-    usePaginationStore()
+    usePagination()
 
   useEffect(() => {
     setTotalCount(totalCount)

--- a/src/components/PaginationComponent.tsx
+++ b/src/components/PaginationComponent.tsx
@@ -3,15 +3,17 @@ import { usePaginationStore } from "@/hooks/useStores"
 import { Pagination } from "@nextui-org/react"
 import { useEffect, useMemo } from "react"
 
-export default function PaginationComponent() {
+export default function PaginationComponent({
+  totalCount,
+}: {
+  totalCount: number
+}) {
   const { pagination, setTotalCount, setPageNumber, setPageSize } =
     usePaginationStore()
 
-  const totalCount = 20
-
   useEffect(() => {
     setTotalCount(totalCount)
-  }, [setTotalCount])
+  }, [setTotalCount, totalCount])
 
   const { pageNumber, pageSize, totalPages } = pagination
 
@@ -51,7 +53,7 @@ export default function PaginationComponent() {
         className="flex gap-1 items-center"
       >
         Results per page:
-        {[4, 8, 12].map(size => (
+        {[3, 6, 12].map(size => (
           <div
             className={`page-size-box ${
               pageSize === size

--- a/src/components/PaginationComponent.tsx
+++ b/src/components/PaginationComponent.tsx
@@ -1,23 +1,49 @@
 "use client"
+import { usePaginationStore } from "@/hooks/useStores"
 import { Pagination } from "@nextui-org/react"
-import React, { useState } from "react"
+import { useEffect, useMemo } from "react"
 
 export default function PaginationComponent() {
-  const [pageSize, setPageSize] = useState(4)
+  const { pagination, setTotalCount, setPageNumber, setPageSize } =
+    usePaginationStore()
+
+  const totalCount = 20
+
+  useEffect(() => {
+    setTotalCount(totalCount)
+  }, [setTotalCount])
+
+  const { pageNumber, pageSize, totalPages } = pagination
+
+  const resultStart = useMemo(
+    () => (pageNumber - 1) * pageSize + 1,
+    [pageNumber, pageSize]
+  )
+
+  const resultEnd = useMemo(
+    () => Math.min(pageSize * pageNumber, totalCount),
+    [pageNumber, pageSize, totalCount]
+  )
+
+  const resultText = useMemo(
+    () => `Showing ${resultStart}-${resultEnd} of ${totalCount} results`,
+    [resultEnd, resultStart, totalCount]
+  )
+
   return (
     <div
       id="pagination-wrapper"
       className="flex justify-between py-2 border-t-2 mt-5 w-full"
     >
-      <div id="pagination-showing-result-container">
-        Showing 1-10 of 23 results
-      </div>
+      <div id="pagination-showing-result-container">{resultText}</div>
       <div id="pagination-page-selector-container">
         <Pagination
-          total={20}
+          total={totalPages}
           initialPage={1}
+          page={pageNumber}
           variant="bordered"
           color="secondary"
+          onChange={setPageNumber}
         />
       </div>
       <div
@@ -33,6 +59,7 @@ export default function PaginationComponent() {
                 : "hover:bg-gray-100"
             }`}
             key={`page-size-${size}`}
+            onClick={() => setPageSize(size)}
           >
             {size}
           </div>

--- a/src/components/navbar/Filters.tsx
+++ b/src/components/navbar/Filters.tsx
@@ -55,12 +55,6 @@ export function Filters() {
     >
       <LoadingWrapper isLoading={isPending} />
       <div
-        id="result-container"
-        className="text-secondary font-semibold text-xl"
-      >
-        Results: 10
-      </div>
-      <div
         id="gender-selection-buttons-container"
         className="flex gap-2 items-center"
       >

--- a/src/components/navbar/Filters.tsx
+++ b/src/components/navbar/Filters.tsx
@@ -3,13 +3,12 @@
 import { useMemberFilters } from "@/hooks/useMemberFilters"
 import type { MemberFilters } from "@/types"
 import { Button } from "@nextui-org/button"
-import { SelectItem } from "@nextui-org/react"
+import { SelectItem, Switch } from "@nextui-org/react"
 import { Select } from "@nextui-org/select"
 import { Slider } from "@nextui-org/slider"
 import { usePathname } from "next/navigation"
 import React, { useMemo } from "react"
 import { FaFemale, FaMale } from "react-icons/fa"
-import { LoadingWrapper } from "../Loading"
 
 export function Filters() {
   const {
@@ -17,7 +16,7 @@ export function Filters() {
     handleAgeFilter,
     handleGenderFilter,
     handleOrderByFilter,
-    isPending,
+    handleHasPhotosFilter,
   } = useMemberFilters()
 
   const genderItems = useMemo(
@@ -53,7 +52,7 @@ export function Filters() {
       id="filters-wrapper"
       className="flex justify-around items-center shadow-md py-2 relative"
     >
-      <LoadingWrapper isLoading={isPending} />
+      {/* <LoadingWrapper isLoading={isPending} /> */}
       <div
         id="gender-selection-buttons-container"
         className="flex gap-2 items-center"
@@ -85,6 +84,17 @@ export function Filters() {
             handleAgeFilter(value as MemberFilters["ageRange"])
           }
         />
+      </div>
+      <div id="has-photo-switch-container">
+        <Switch
+          isSelected={filters.hasPhotos}
+          onValueChange={handleHasPhotosFilter}
+          classNames={{ base: "flex flex-col-reverse items-center" }}
+          size="sm"
+          color="secondary"
+        >
+          Has Photos
+        </Switch>
       </div>
       <div id="order-by-selector-container" className="w-1/4">
         <Select

--- a/src/components/navbar/TopNav.tsx
+++ b/src/components/navbar/TopNav.tsx
@@ -65,7 +65,7 @@ export const TopNav = async () => {
           )}
         </NavbarContent>
       </Navbar>
-      <FiltersWrapper />
+      {/* <FiltersWrapper /> */}
     </>
   )
 }

--- a/src/components/navbar/TopNav.tsx
+++ b/src/components/navbar/TopNav.tsx
@@ -65,7 +65,7 @@ export const TopNav = async () => {
           )}
         </NavbarContent>
       </Navbar>
-      {/* <FiltersWrapper /> */}
+      <FiltersWrapper />
     </>
   )
 }

--- a/src/hooks/storeDefaultStates.ts
+++ b/src/hooks/storeDefaultStates.ts
@@ -1,0 +1,3 @@
+export const defaultGenders = ["female", "male"]
+export const defaultAgeRange = [18, 100]
+export const defaultOrderBy = "updated"

--- a/src/hooks/useMemberFilters.tsx
+++ b/src/hooks/useMemberFilters.tsx
@@ -9,24 +9,22 @@ export const useMemberFilters = () => {
   const path = usePathname()
   const router = useRouter()
   const { filters, setFilters } = useFiltersStore()
-  const { ageRange, gender, orderBy } = filters
-  const [isPending, startTransition] = useTransition()
+  const { ageRange, gender, orderBy, hasPhotos } = filters
 
   useEffect(() => {
-    startTransition(() => {
-      const params = new URLSearchParams()
-      params.set("ageRange", ageRange.join("-"))
-      params.set("orderBy", orderBy)
+    const params = new URLSearchParams()
+    params.set("ageRange", ageRange.join("-"))
+    params.set("orderBy", orderBy)
+    params.set("hasPhotos", hasPhotos.toString())
 
-      // special treatment of gender state before setting params
-      if (!gender.length) {
-        params.set("gender", "")
-      } else {
-        params.set("gender", gender.join("&"))
-      }
-      router.replace(`${path}?${params}`)
-    })
-  }, [ageRange, gender, orderBy, path, router])
+    // special treatment of gender state before setting params
+    if (!gender.length) {
+      params.set("gender", "")
+    } else {
+      params.set("gender", gender.join("&"))
+    }
+    router.replace(`${path}?${params}`)
+  }, [ageRange, gender, orderBy, path, router, hasPhotos])
 
   // below three handlers update states only
   const handleAgeFilter = useCallback(
@@ -58,11 +56,18 @@ export const useMemberFilters = () => {
     },
     [setFilters]
   )
+
+  const handleHasPhotosFilter = useCallback(
+    (value: boolean) => {
+      setFilters("hasPhotos", value)
+    },
+    [setFilters]
+  )
   return {
     filters,
     handleAgeFilter,
     handleGenderFilter,
     handleOrderByFilter,
-    isPending,
+    handleHasPhotosFilter,
   }
 }

--- a/src/hooks/useNotificationChannel.ts
+++ b/src/hooks/useNotificationChannel.ts
@@ -17,8 +17,6 @@ export const useNotificationChannel = (userId: string | null) => {
 
   const handleNewMessage = useCallback(
     (message: MessageDTO) => {
-      console.log("path in handle", path)
-
       // if user is on "/messages" and in inbox, we update messages state so message table is updated
       if (path === "/messages" && searchParams.get("container") !== "outbox") {
         useMessagesStore.setState(state => {

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -18,7 +18,7 @@ export default function usePagination() {
     startTransition(() => {
       const params = new URLSearchParams(searchParams)
       params.set("pageSize", pageSize.toString())
-      params.set("page", pageNumber.toString())
+      params.set("pageNumber", pageNumber.toString())
 
       router.replace(`${path}?${params}`)
     })

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -6,13 +6,12 @@ export default function usePagination() {
   const path = usePathname()
   const router = useRouter()
   const searchParams = useSearchParams()
-  const { pagination } = usePaginationStore(state => ({
-    pagination: state.pagination,
-  }))
+  const { pagination, setTotalCount, setPageNumber, setPageSize } =
+    usePaginationStore()
 
   const { pageNumber, pageSize } = pagination
 
-  const [_isPending, startTransition] = useTransition()
+  const [_, startTransition] = useTransition()
 
   useEffect(() => {
     startTransition(() => {
@@ -23,4 +22,11 @@ export default function usePagination() {
       router.replace(`${path}?${params}`)
     })
   }, [pageNumber, pageSize, path, router, searchParams])
+
+  return {
+    pagination,
+    setTotalCount,
+    setPageNumber,
+    setPageSize,
+  }
 }

--- a/src/hooks/usePagination.tsx
+++ b/src/hooks/usePagination.tsx
@@ -1,0 +1,26 @@
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { useTransition, useEffect } from "react"
+import { usePaginationStore } from "./useStores"
+
+export default function usePagination() {
+  const path = usePathname()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { pagination } = usePaginationStore(state => ({
+    pagination: state.pagination,
+  }))
+
+  const { pageNumber, pageSize } = pagination
+
+  const [_isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    startTransition(() => {
+      const params = new URLSearchParams(searchParams)
+      params.set("pageSize", pageSize.toString())
+      params.set("page", pageNumber.toString())
+
+      router.replace(`${path}?${params}`)
+    })
+  }, [pageNumber, pageSize, path, router, searchParams])
+}

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -45,6 +45,7 @@ type MessagesState = {
   remove: (id: string) => void
   set: (messages: MessageDTO[]) => void
   updateUnreadCount: (n: number) => void
+  resetMessages: () => void
 }
 
 export const useMessagesStore = create<MessagesState>()(
@@ -58,9 +59,16 @@ export const useMessagesStore = create<MessagesState>()(
         set(state => ({
           messages: state.messages.filter(m => m.id !== id),
         })),
-      set: messages => set({ messages }),
+      set: messages =>
+        set(state => {
+          // remove dup messages
+          const map = new Map([...state.messages, ...messages].map(m => [m.id, m]))
+          const uniqMessages = Array.from(map.values())
+          return { messages: uniqMessages }
+        }),
       updateUnreadCount: n =>
         set(state => ({ unreadCount: state.unreadCount + n })),
+      resetMessages: () => set({ messages: [] }),
     }),
     {
       name: "messages_store",

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -5,6 +5,11 @@
 import { create } from "zustand"
 import { devtools } from "zustand/middleware"
 import { MessageDTO, type MemberFilters, type PagingResult } from "@/types"
+import {
+  defaultAgeRange,
+  defaultGenders,
+  defaultOrderBy,
+} from "./storeDefaultStates"
 
 type PresenceState = {
   members: string[]
@@ -72,16 +77,16 @@ export const useFiltersStore = create<FiltersState>()(
   devtools(
     set => ({
       filters: {
-        ageRange: [18, 100],
-        orderBy: "updated",
-        gender: ["female", "male"],
+        ageRange: defaultAgeRange,
+        orderBy: defaultOrderBy,
+        gender: defaultGenders,
       },
       setFilters: (filterName, value) => {
         set(state => ({ filters: { ...state.filters, [filterName]: value } }))
       },
     }),
     {
-      name: "filterss_store",
+      name: "filters_store",
     }
   )
 )

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -108,7 +108,7 @@ export const usePaginationStore = create<PaginationState>()(
       setTotalCount: totalCount =>
         set(state => ({
           pagination: {
-            pageNumber: 1, // whenever we change settings, go back to page 1
+            pageNumber: 1, // whenever totalCount changes, go back to page 1
             pageSize: state.pagination.pageSize,
             totalCount,
             totalPages: Math.ceil(totalCount / state.pagination.pageSize),
@@ -126,7 +126,7 @@ export const usePaginationStore = create<PaginationState>()(
           pagination: {
             ...state.pagination,
             pageSize: size,
-            pageNumber: 1, // reset page to 1 when page size changes
+            pageNumber: 1, // whenever page size changes, go back to page 1
             totalPages: Math.ceil(state.pagination.totalCount / size),
           },
         })),

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -88,6 +88,7 @@ export const useFiltersStore = create<FiltersState>()(
         ageRange: defaultAgeRange,
         orderBy: defaultOrderBy,
         gender: defaultGenders,
+        hasPhotos: false,
       },
       setFilters: (filterName, value) => {
         set(state => ({ filters: { ...state.filters, [filterName]: value } }))

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -49,12 +49,12 @@ type MemberFilters = {
   ageRange: number[]
   orderBy: string
   gender: string[]
+  hasPhotos: boolean
 }
-
 
 type PagingParams = {
   pageNumber: number // current page
-  pageSize:number // how many items per page
+  pageSize: number // how many items per page
 }
 
 /**
@@ -62,11 +62,10 @@ type PagingParams = {
  */
 type PagingResult = {
   totalPages: number
-  totalCount:number // the number of all possible results
+  totalCount: number // the number of all possible results
 } & PagingParams
 
-
-type PaginationResponse<T> ={
+type PaginationResponse<T> = {
   items: T[]
   totalCount: number
 }
@@ -76,6 +75,7 @@ type GetMembersParams = {
   ageRange?: string
   orderBy?: string
   gender?: string
+  hasPhotos?: string
   pageNumber?: string
   pageSize?: string
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -50,3 +50,23 @@ type MemberFilters = {
   orderBy: string
   gender: string[]
 }
+
+
+type PagingParams = {
+  pageNumber: number // current page
+  pageSize:number // how many items per page
+}
+
+/**
+ * big picture to tell all important metadata about pagination
+ */
+type PagingResult = {
+  totalPages: number
+  totalCount:number // the number of all possible results
+} & PagingParams
+
+
+type PaginationResponse<T> ={
+  items: T[]
+  totalCount: number
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -70,3 +70,12 @@ type PaginationResponse<T> ={
   items: T[]
   totalCount: number
 }
+
+/** Type for getMembers server action parameters*/
+type GetMembersParams = {
+  ageRange?: string
+  orderBy?: string
+  gender?: string
+  pageNumber?: string
+  pageSize?: string
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -46,7 +46,7 @@ type MessageDTO = {
  * Type for the 'filters' state 
  */
 type MemberFilters = {
-  ageRange: [number, number]
+  ageRange: number[]
   orderBy: string
   gender: string[]
 }


### PR DESCRIPTION
Last PR for section 9

## User flow completed
- added pagination to `/members` page

![Screenshot 2024-08-26 at 4 21 17 PM](https://github.com/user-attachments/assets/261698b8-d02d-4065-993c-a413485578b1)
- added pagination to `/messages` page

![2024-08-26 16 22 30](https://github.com/user-attachments/assets/2314acf5-a1f2-42bd-b071-65fa90536661)

## Tech details
1. Used the **offset** strategy for members pagination, where at page number N, the fetch request will skip (N-1) * pageSize results and just return pageSize number of results
2. Used the **cursor** strategy for messages pagination. In every request (except the initial one), we pass a date string as a cursor to fetch x number of results prior to that date. We update the messages table with new messages.

## Takeaways
There are two directions to sync search params in the URL with states. User action -> update params -> hooks listening to params and update state -> UI re-render
OR: User action -> update states -> side effect to update URL -> fetch new results based on params -> UI re-render

Both are acceptable and have pros and cons. We choose the second direction because we want to save the filtering and pagination preferences so users don't lose them when they navigation away and back to the members page. 
